### PR TITLE
Manually save session before redirecting

### DIFF
--- a/index.js
+++ b/index.js
@@ -474,7 +474,12 @@ CASAuthentication.prototype._handleTicket = function(req, res, next) {
                     if (this.session_info) {
                         req.session[ this.session_info ] = attributes || {};
                     }
-                    res.redirect(req.session.cas_return_to);
+                    res.session.save(err => {
+                        if (err) {
+                            return next(err);
+                        } 
+                        res.redirect(req.session.cas_return_to);
+                    });
                 }
             }.bind(this));
         }.bind(this));


### PR DESCRIPTION
There is the possibility of a race condition where the session doesn't save properly before _handleTicket redirects after validating the service ticket. This can result in a login loop. This PR manually saves the session before redirecting to avoid this issue. For me, this occurred when using `session-file-store` as a session store.